### PR TITLE
Only require `__STDC_LIMIT_MACROS` to be defined when building with MSC

### DIFF
--- a/classlib/utils/IntBits.h
+++ b/classlib/utils/IntBits.h
@@ -1,8 +1,17 @@
 #ifndef CLASSLIB_INT_BITS_H
 # define CLASSLIB_INT_BITS_H
-# ifndef __STDC_LIMIT_MACROS
-#  error This header requires __STDC_LIMIT_MACROS to be defined
-# endif
+
+// The __STDC_LIMIT_MACROS needs to be defined such that the nonstdint.h header
+// knows that it has to define the INT<N>_MAX macros itself. However, this is
+// only necessary when using the Microsoft compiler. In the other cases, the
+// nonstdint.h header is just an alias to the system stdint.h, which is where
+// the INT<N>_MAX macros get defined.
+# if _MSC_VER
+#  ifndef __STDC_LIMIT_MACROS
+#   error This header requires __STDC_LIMIT_MACROS to be defined
+#  endif
+# endif // _MSC_VER
+
 # include "classlib/utils/BitTraits.h"
 # include "classlib/sysapi/nonstdint.h"
 


### PR DESCRIPTION
There was a false-positive preprocessor error when I tried to build CMSSW again on my Arch Linux machine:
```txt
/usr/include/classlib/utils/IntBits.h:4:4: error: #error This header requires __STDC_LIMIT_MACROS to be defined
    4 | #  error This header requires __STDC_LIMIT_MACROS to be defined
```

The __STDC_LIMIT_MACROS needs to be defined such that the `nonstdint.h` header included right after knows that it has to define the INT<N>_MAX macros itself. However, this is only necessary when using the Microsoft compiler. In the other cases, the nonstdint.h header is just an alias to the system stdint.h, which is where the INT<N>_MAX macros get defined in any case.

Probably, this error was not relevant before, because somehow the `stdint.h` header that defines this macro was always included before `classlib/utils/IntBits.h` in CMSSW, and only my differnt Linux environment has that problem (so far).